### PR TITLE
Terminal UI batching, not actually LanderSound

### DIFF
--- a/Terminal UI/lander.py
+++ b/Terminal UI/lander.py
@@ -12,6 +12,8 @@ import random
 
 pygame.init()
 
+clock = pygame.time.Clock()
+
 termwidth = 120
 termheight = 60
 
@@ -215,7 +217,9 @@ def main():
 		pygame.display.flip()
 		
 
-		time.sleep(1/framerate)
+		#time.sleep(1/framerate)
+		clock.tick(framerate)
+		print(clock.get_fps())
 		framenum += 1
 
 if __name__ == '__main__':

--- a/Terminal UI/terminalUI.py
+++ b/Terminal UI/terminalUI.py
@@ -205,11 +205,26 @@ class textSurface: # Similar in concept to a Pygame surface but with text instea
 	def drawPygame(self,destinationSurface, position = (0, 0)): # Draw the surface to a given Pygame surface
 		surface = pygame.Surface((self.width * fontsize[0], self.height * fontsize[1]), SRCALPHA)
 		surface.fill(color=self.defaultbgcolor)
+		batchwidth = 0
+		batchcolor = None
 		for i in range(self.height): # Draw background
+			batchwidth = 0
+			batchcolor = None
 			for j in range(self.width):
-				if self.colorarray[i][j][1] != self.defaultbgcolor:
-					backgroundrect = pygame.Rect((j * fontsize[0], (i * fontsize[1])), (fontsize[0], fontsize[1]))
-					surface.fill(color=self.colorarray[i][j][1], rect=backgroundrect)
+				thiscolor = self.colorarray[i][j][1]
+				if batchwidth == 0 or batchcolor == thiscolor:
+					batchwidth += 1
+					batchcolor = thiscolor
+				else:
+					#if batchcolor != self.defaultbgcolor:
+					backgroundrect = pygame.Rect(((j-batchwidth) * fontsize[0], (i * fontsize[1])), (fontsize[0]*batchwidth, fontsize[1]))
+					surface.fill(color=batchcolor, rect=backgroundrect)
+					batchwidth = 1
+					batchcolor = thiscolor
+			if batchwidth > 0:
+				if batchcolor != self.defaultbgcolor:
+					backgroundrect = pygame.Rect(((self.width-batchwidth) * fontsize[0], (i * fontsize[1])), (fontsize[0]*batchwidth, fontsize[1]))
+					surface.fill(color=batchcolor, rect=backgroundrect)
 		for i in range(self.height):
 			for j in range(self.width):
 				charactertodraw = self.array[i][j]

--- a/Terminal UI/terminalUI.py
+++ b/Terminal UI/terminalUI.py
@@ -204,12 +204,12 @@ class textSurface: # Similar in concept to a Pygame surface but with text instea
 	
 	def drawPygame(self,destinationSurface, position = (0, 0)): # Draw the surface to a given Pygame surface
 		surface = pygame.Surface((self.width * fontsize[0], self.height * fontsize[1]), SRCALPHA)
+		surface.fill(color=self.defaultbgcolor)
 		for i in range(self.height): # Draw background
 			for j in range(self.width):
-				charactertodraw = self.array[i][j]
-				charactersurface = pygame.Surface((fontsize[0], fontsize[1]), SRCALPHA) # Generate surface the size of a character
-				charactersurface.fill(self.colorarray[i][j][1]) # Fill surface with background color
-				surface.blit(charactersurface, (j * fontsize[0], (i * fontsize[1]))) # Draw surface to target cell
+				if self.colorarray[i][j][1] != self.defaultbgcolor:
+					backgroundrect = pygame.Rect((j * fontsize[0], (i * fontsize[1])), (fontsize[0], fontsize[1]))
+					surface.fill(color=self.colorarray[i][j][1], rect=backgroundrect)
 		for i in range(self.height):
 			for j in range(self.width):
 				charactertodraw = self.array[i][j]

--- a/Terminal UI/terminalUI.py
+++ b/Terminal UI/terminalUI.py
@@ -216,9 +216,9 @@ class textSurface: # Similar in concept to a Pygame surface but with text instea
 					batchwidth += 1
 					batchcolor = thiscolor
 				else:
-					#if batchcolor != self.defaultbgcolor:
-					backgroundrect = pygame.Rect(((j-batchwidth) * fontsize[0], (i * fontsize[1])), (fontsize[0]*batchwidth, fontsize[1]))
-					surface.fill(color=batchcolor, rect=backgroundrect)
+					if batchcolor != self.defaultbgcolor:
+						backgroundrect = pygame.Rect(((j-batchwidth) * fontsize[0], (i * fontsize[1])), (fontsize[0]*batchwidth, fontsize[1]))
+						surface.fill(color=batchcolor, rect=backgroundrect)
 					batchwidth = 1
 					batchcolor = thiscolor
 			if batchwidth > 0:

--- a/Terminal UI/terminalUI.py
+++ b/Terminal UI/terminalUI.py
@@ -212,19 +212,18 @@ class textSurface: # Similar in concept to a Pygame surface but with text instea
 			batchcolor = None
 			for j in range(self.width):
 				thiscolor = self.colorarray[i][j][1]
-				if batchwidth == 0 or batchcolor == thiscolor:
+				if batchwidth == 0 or batchcolor == thiscolor: # Start or extend batch if it matches
 					batchwidth += 1
 					batchcolor = thiscolor
-				else:
-					if batchcolor != self.defaultbgcolor:
+				else: # If it doesn't match, write the previous batch and start a new one
+					if batchcolor != self.defaultbgcolor: 
 						backgroundrect = pygame.Rect(((j-batchwidth) * fontsize[0], (i * fontsize[1])), (fontsize[0]*batchwidth, fontsize[1]))
 						surface.fill(color=batchcolor, rect=backgroundrect)
 					batchwidth = 1
 					batchcolor = thiscolor
-			if batchwidth > 0:
-				if batchcolor != self.defaultbgcolor:
-					backgroundrect = pygame.Rect(((self.width-batchwidth) * fontsize[0], (i * fontsize[1])), (fontsize[0]*batchwidth, fontsize[1]))
-					surface.fill(color=batchcolor, rect=backgroundrect)
+			if batchcolor != self.defaultbgcolor:# End of line, write lingering batch
+				backgroundrect = pygame.Rect(((self.width-batchwidth) * fontsize[0], (i * fontsize[1])), (fontsize[0]*batchwidth, fontsize[1]))
+				surface.fill(color=batchcolor, rect=backgroundrect)
 		for i in range(self.height):
 			for j in range(self.width):
 				charactertodraw = self.array[i][j]


### PR DESCRIPTION
I added background batching to the terminal UI module. Instead of drawing one rect per glyph, it crawls through the line adding up sequential cells of the same color, then draws them as a single rect once it reaches a cell of a different color or the end of the line.

Also switched from sleeping 1/framerate per frame to using pygame.time.Clock() to properly handle framerate in lander.py